### PR TITLE
Exporting size/vsize through API

### DIFF
--- a/lib/services/bitcoind.js
+++ b/lib/services/bitcoind.js
@@ -1984,6 +1984,10 @@ Bitcoin.prototype.getDetailedTransaction = function(txid, callback) {
           return done(self._wrapRPCError(err));
         }
         var result = response.result;
+
+        // returns vsize for segwit-positive coins,
+        // regular size if segwit is disbled
+        var size = result.vsize == null ? result.size : result.vsize;
         var tx = {
           hex: result.hex,
           blockHash: result.blockhash,
@@ -1992,6 +1996,7 @@ Bitcoin.prototype.getDetailedTransaction = function(txid, callback) {
           version: result.version,
           hash: txid,
           locktime: result.locktime,
+          size: size,
         };
 
         if (result.vin[0] && result.vin[0].coinbase) {


### PR DESCRIPTION
This is needed for insight to display "correct" size and fee/byte for segwit transactions. 

(Or, you can count the transaction size by parsing the transaction in javascript, but that's not really necessary if the daemon can do that, probably more correctly.)

There is also necessary to patch insight-api for this; I will send the PR too. 

edit: done - https://github.com/litecoin-project/insight-lite-api/pull/3

The change is backwards compatible; if the underlying daemon doesn't support segwit and doesn't export vsize, regular size is exported.