### PR TITLE
Improve scripts/download to be customisable via env vars

### DIFF
--- a/scripts/download
+++ b/scripts/download
@@ -38,35 +38,61 @@ fi
 : ${LTC_VERIFY="0"}
 : ${VERIFY_BITCOIN_DOWNLOAD="$LTC_VERIFY"}
 : ${SKIP_BITCOIN_DOWNLOAD="0"}
+: ${USE_CURL="1"}
+: ${USE_WGET="1"}
+
+hascmd() {
+    command -v "$@" &> /dev/null
+}
+
+(( USE_CURL )) && ! has_cmd curl && USE_CURL=0 || true
+(( USE_WGET )) && ! has_cmd wget && USE_WGET=0 || true
+if ! (( USE_CURL )) && ! hascmd wget && hascmd curl; then USE_CURL=1 USE_WGET=0; fi
+if ! (( USE_WGET )) && ! hascmd curl && hascmd wget; then USE_CURL=0 USE_WGET=1; fi
 
 download_bitcoind() {
+    local bdir="${root_dir}/bin"
+    [ -x "$root_dir" ] || chmod +x "$root_dir"
+    [ -r "$root_dir" ] || chmod +r "$root_dir"
+    [ -w "$root_dir" ] || chmod +w "$root_dir"
 
-    cd "${root_dir}/bin"
+    [[ -d "$bdir" ]] || mkdir -pv "$bdir"
+    [ -x "$bdir" ] || chmod +x "$bdir"
+    [ -r "$bdir" ] || chmod +r "$bdir"
+    [ -w "$bdir" ] || chmod +w "$bdir"
 
-    echo "Downloading litecoin: ${binary_url}"
+    cd "$bdir"
 
-    is_curl=1
-    if hash curl 2>/dev/null; then
+    echo " [...] Testing URL works: ${binary_url}"
+    
+    if (( USE_CURL )); then
         curl --fail -I "$binary_url" >/dev/null 2>&1
-    else
-        is_curl=0
+        _ret=$?
+    elif (( USE_WGET )); then
         wget --server-response --spider "$binary_url" >/dev/null 2>&1
+        _ret=$?
+    else
+        >&2 echo -e "\n [!!!] Neither 'curl' nor 'wget' are available! Cannot download litecoind. Please install either 'curl' and/or 'wget' from your package manager...\n"
+        return 8
     fi
 
-    if test $? -eq 0; then
-        if (( is_curl )); then
+    echo -e "\n [...] Downloading litecoin from '${binary_url}' to file: ${PWD}/${tarball_name} \n"
+    if (( ret == 0 )); then
+        if (( USE_CURL )); then
             curl -L "$binary_url" > "$tarball_name"
             (( VERIFY_BITCOIN_DOWNLOAD )) && curl -L "$shasums_url" > SHA256SUMS.asc || true
         else
-            wget $binary_url
+            wget -O "$tarball_name" "$binary_url"
             (( VERIFY_BITCOIN_DOWNLOAD )) && wget $shasums_url || true
         fi
-        if test -e "${tarball_name}"; then
-            echo "Unpacking litecoin distribution"
-            tar -xvzf $tarball_name
-            if test $? -eq 0; then
+        if [[ -f "$tarball_name" ]]; then
+            echo -e "\n [...] Unpacking litecoin distribution from tarball: ${PWD}/${tarball_name}\n"
+            if tar -xvzf "$tarball_name"; then
+                echo -e "\n [+++] Successfully unpacked Litecoin tarball. Linking litecoind...\n"
                 ln -sf "litecoin-${version}/bin/litecoind"
                 return;
+            else
+                >&2 echo -e "\n [!!!] Failed to unpack tarball: ${PWD}/${tarball_name}\n"
             fi
         fi
     fi

--- a/scripts/download
+++ b/scripts/download
@@ -8,7 +8,9 @@ set -e
 : ${LTC_ARCH=""}
 : ${LTC_TARBALL=""}
 
+#root_dir="$(realpath "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/..")"
 root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/.."
+
 [[ -n "$LTC_PLATFORM" ]] && platform="$LTC_PLATFORM" || platform=`uname -a | awk '{print tolower($1)}'`
 [[ -n "$LTC_ARCH" ]] && arch="$LTC_ARCH" || arch=`uname -m`
 version="$LTC_VERSION"
@@ -45,6 +47,8 @@ hascmd() {
     command -v "$@" &> /dev/null
 }
 
+has_cmd() { hascmd "$@"; }
+
 (( USE_CURL )) && ! has_cmd curl && USE_CURL=0 || true
 (( USE_WGET )) && ! has_cmd wget && USE_WGET=0 || true
 if ! (( USE_CURL )) && ! hascmd wget && hascmd curl; then USE_CURL=1 USE_WGET=0; fi
@@ -52,16 +56,17 @@ if ! (( USE_WGET )) && ! hascmd curl && hascmd wget; then USE_CURL=0 USE_WGET=1;
 
 download_bitcoind() {
     local bdir="${root_dir}/bin"
-    [ -x "$root_dir" ] || chmod +x "$root_dir"
-    [ -r "$root_dir" ] || chmod +r "$root_dir"
-    [ -w "$root_dir" ] || chmod +w "$root_dir"
+    #[ -x "$root_dir" ] || chmod +x "$root_dir"
+    #[ -r "$root_dir" ] || chmod +r "$root_dir"
+    #[ -w "$root_dir" ] || chmod +w "$root_dir"
 
-    [[ -d "$bdir" ]] || mkdir -pv "$bdir"
-    [ -x "$bdir" ] || chmod +x "$bdir"
-    [ -r "$bdir" ] || chmod +r "$bdir"
-    [ -w "$bdir" ] || chmod +w "$bdir"
+    #[[ -d "$bdir" ]] || mkdir -pv "$bdir"
+    #[ -x "$bdir" ] || chmod +x "$bdir"
+    #[ -r "$bdir" ] || chmod +r "$bdir"
+    #[ -w "$bdir" ] || chmod +w "$bdir"
 
     cd "$bdir"
+    echo " >>> Binary dir is: $bdir"
 
     echo " [...] Testing URL works: ${binary_url}"
     

--- a/scripts/download
+++ b/scripts/download
@@ -1,29 +1,43 @@
 #!/bin/bash
 
 set -e
+: ${LTC_URL="https://github.com/litecoin-project/litecore-litecoin/releases/download"}
+: ${LTC_VERSION="0.13.2"}
+: ${LTC_TAG="v0.13.2.1-litecore-rc2"}
+: ${LTC_PLATFORM=""}
+: ${LTC_ARCH=""}
+: ${LTC_TARBALL=""}
 
 root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/.."
-platform=`uname -a | awk '{print tolower($1)}'`
-arch=`uname -m`
-version="0.13.2"
-url="https://github.com/litecoin-project/litecore-litecoin/releases/download"
-tag="v0.13.2.1-litecore-rc2"
+[[ -n "$LTC_PLATFORM" ]] && platform="$LTC_PLATFORM" || platform=`uname -a | awk '{print tolower($1)}'`
+[[ -n "$LTC_ARCH" ]] && arch="$LTC_ARCH" || arch=`uname -m`
+version="$LTC_VERSION"
+url="$LTC_URL"
+tag="$LTC_TAG"
 
-if [ "${platform}" == "linux" ]; then
-    if [ "${arch}" == "x86_64" ]; then
-        tarball_name="litecoin-${version}-x86_64-linux-gnu.tar.gz"
-    elif [ "${arch}" == "x86_32" ]; then
-        tarball_name="litecoin-${version}-i686-pc-linux-gnu.tar.gz"
+if [[ -z "$LTC_TARBALL" ]]; then
+    if [ "${platform}" == "linux" ]; then
+        if [ "${arch}" == "x86_64" ]; then
+            tarball_name="litecoin-${version}-x86_64-linux-gnu.tar.gz"
+        elif [ "${arch}" == "x86_32" ]; then
+            tarball_name="litecoin-${version}-i686-pc-linux-gnu.tar.gz"
+        fi
+    elif [ "${platform}" == "darwin" ]; then
+        tarball_name="litecoin-${version}-osx64.tar.gz"
+    else
+        echo "Litecoin binary distribution not available for platform and architecture"
+        exit 5
     fi
-elif [ "${platform}" == "darwin" ]; then
-    tarball_name="litecoin-${version}-osx64.tar.gz"
 else
-    echo "Litecoin binary distribution not available for platform and architecture"
-    exit -1
+    tarball_name="$LTC_TARBALL"
 fi
 
-binary_url="${url}/${tag}/${tarball_name}"
-shasums_url="${url}/${tag}/SHA256SUMS.asc"
+: ${binary_url="${url}/${tag}/${tarball_name}"}
+: ${shasums_url="${url}/${tag}/SHA256SUMS.asc"}
+
+: ${LTC_VERIFY="0"}
+: ${VERIFY_BITCOIN_DOWNLOAD="$LTC_VERIFY"}
+: ${SKIP_BITCOIN_DOWNLOAD="0"}
 
 download_bitcoind() {
 
@@ -31,21 +45,21 @@ download_bitcoind() {
 
     echo "Downloading litecoin: ${binary_url}"
 
-    is_curl=true
+    is_curl=1
     if hash curl 2>/dev/null; then
-        curl --fail -I $binary_url >/dev/null 2>&1
+        curl --fail -I "$binary_url" >/dev/null 2>&1
     else
-        is_curl=false
-        wget --server-response --spider $binary_url >/dev/null 2>&1
+        is_curl=0
+        wget --server-response --spider "$binary_url" >/dev/null 2>&1
     fi
 
     if test $? -eq 0; then
-        if [ "${is_curl}" = true ]; then
-            curl -L $binary_url > $tarball_name
-            curl -L $shasums_url > SHA256SUMS.asc
+        if (( is_curl )); then
+            curl -L "$binary_url" > "$tarball_name"
+            (( VERIFY_BITCOIN_DOWNLOAD )) && curl -L "$shasums_url" > SHA256SUMS.asc || true
         else
             wget $binary_url
-            wget $shasums_url
+            (( VERIFY_BITCOIN_DOWNLOAD )) && wget $shasums_url || true
         fi
         if test -e "${tarball_name}"; then
             echo "Unpacking litecoin distribution"
@@ -57,7 +71,7 @@ download_bitcoind() {
         fi
     fi
     echo "Litecoin binary distribution could not be downloaded"
-    exit -1
+    exit 2
 }
 
 verify_download() {
@@ -82,16 +96,9 @@ verify_download() {
     fi
 }
 
-download=1
-verify=0
+(( SKIP_BITCOIN_DOWNLOAD )) && download=0 || download=1
+(( VERIFY_BITCOIN_DOWNLOAD )) && verify=1 || verify=0
 
-if [ "${SKIP_BITCOIN_DOWNLOAD}" = 1 ]; then
-    download=0;
-fi
-
-if [ "${VERIFY_BITCOIN_DOWNLOAD}" = 1 ]; then
-    verify=1;
-fi
 
 while [ -n "$1" ]; do
   param="$1"
@@ -108,12 +115,16 @@ while [ -n "$1" ]; do
   shift
 done
 
-if [ "${download}" = 1 ]; then
+if (( download )); then
     download_bitcoind
+else
+    >&2 echo -e "\n [!!!] Not downloading litecoind, as \$download is 0\n"
 fi
 
-if [ "${verify}" = 1 ]; then
+if (( verify )); then
     verify_download
+else
+    >&2 echo -e "\n [!!!] Not verifying litecoind, as \$verify is 0\n"
 fi
 
 exit 0


### PR DESCRIPTION
# The Problems

Currently, a lot of vars are hardcoded into the script, which means when things go wrong trying to install it (especially from npm), there's no way for a user to rectify issues as simple as a broken URL without cloning the repo and editing the script.

Similarly, if the arch / platform detection fails, your only recourse is editing the script...

# The solution

Now, it's easy to adjust various vars simply via setting environment variables, whether you export them, or specify them inline for a command.

**NOTE:** Currently, the SHA256SUMs links are broken, so by default, `LTC_VERIFY` is set to `0` (false), to prevent installation failures due to the missing SHA256SUMs file.

# Example uses

For example, lets say you want to download the litecoind installation from `example.com` instead of Github, this can be done easily via the `LTC_TARBALL` env var:

```
LTC_TARBALL="https://example.com/litecoin-v0.13.2-x86_64-linux.tar.gz" npm install -g litecore-node@latest
```

Or, if you'd prefer to disable the automatic download of litecoind, and install it into litecore manually:

```
SKIP_BITCOIN_DOWNLOAD=1 npm install -g litecore-node@latest
```

Possibly, the script can't correctly detect your system's architecture / platform, this issue can now easily be solved through supplying the arch and/or platform as an env var:

```
LTC_ARCH="x86_64" LTC_PLATFORM="linux" npm install -g litecore-node@latest
```

**And more!** - Simply take a look at the first 20 lines or so of `scripts/download` to see the various ENV vars that are now available (vars that look like `: ${hello="world"}` are overridable vars, which contain just a default fallback value if the variable isn't defined in the environment)
